### PR TITLE
edit person using the same form

### DIFF
--- a/src/Messages.elm
+++ b/src/Messages.elm
@@ -1,12 +1,13 @@
 module Messages exposing (..)
 
 import Material
-import Models exposing (Gender, PersonId)
+import Models exposing (Gender, PersonId, Person)
 
 
 type Msg
     = NoOp
     | ChangePersonId (Maybe PersonId)
+    | UpdatePerson Person
     | ChangePersonName String
     | ChangePersonGender Gender
     | ToggleIsPersonSelf

--- a/src/Messages.elm
+++ b/src/Messages.elm
@@ -8,6 +8,6 @@ type Msg
     = NoOp
     | ChangePersonName String
     | ChangePersonGender Gender
-    | ToggleIsYourself
+    | ToggleIsPersonSelf
     | Save
     | Mdl (Material.Msg Msg)

--- a/src/Messages.elm
+++ b/src/Messages.elm
@@ -1,11 +1,12 @@
 module Messages exposing (..)
 
 import Material
-import Models exposing (Gender)
+import Models exposing (Gender, PersonId)
 
 
 type Msg
     = NoOp
+    | ChangePersonId (Maybe PersonId)
     | ChangePersonName String
     | ChangePersonGender Gender
     | ToggleIsPersonSelf

--- a/src/Messages.elm
+++ b/src/Messages.elm
@@ -6,7 +6,6 @@ import Models exposing (Gender, PersonId, Person)
 
 type Msg
     = NoOp
-    | ChangePersonId (Maybe PersonId)
     | UpdatePerson Person
     | ChangePersonName String
     | ChangePersonGender Gender

--- a/src/Messages.elm
+++ b/src/Messages.elm
@@ -1,7 +1,8 @@
 module Messages exposing (..)
 
-import Models exposing (Gender)
 import Material
+import Models exposing (Gender)
+
 
 type Msg
     = NoOp

--- a/src/Models.elm
+++ b/src/Models.elm
@@ -14,7 +14,7 @@ type alias Person =
     , fatherId : Maybe PersonId
     , motherId : Maybe PersonId
     , spouseId : Maybe PersonId
-    , isYourself : Bool
+    , isPersonSelf : Bool
     }
 
 
@@ -27,7 +27,7 @@ type alias Model =
     { people : List Person
     , personName : String
     , personGender : Gender
-    , isYourself : Bool
+    , isPersonSelf : Bool
     , mdl : Material.Model
     }
 
@@ -37,7 +37,7 @@ initialModel =
     { people = []
     , personName = ""
     , personGender = Male
-    , isYourself = False
+    , isPersonSelf = False
     , mdl = Material.model
     }
 
@@ -50,5 +50,5 @@ newPerson model =
     , fatherId = Nothing
     , motherId = Nothing
     , spouseId = Nothing
-    , isYourself = model.isYourself
+    , isPersonSelf = model.isPersonSelf
     }

--- a/src/Models.elm
+++ b/src/Models.elm
@@ -2,6 +2,7 @@ module Models exposing (..)
 
 import Material
 
+
 type alias PersonId =
     Int
 
@@ -13,7 +14,7 @@ type alias Person =
     , fatherId : Maybe PersonId
     , motherId : Maybe PersonId
     , spouseId : Maybe PersonId
-    , isYourself: Bool
+    , isYourself : Bool
     }
 
 

--- a/src/Models.elm
+++ b/src/Models.elm
@@ -25,6 +25,7 @@ type Gender
 
 type alias Model =
     { people : List Person
+    , personId : Maybe Int
     , personName : String
     , personGender : Gender
     , isPersonSelf : Bool
@@ -35,6 +36,7 @@ type alias Model =
 initialModel : Model
 initialModel =
     { people = []
+    , personId = Nothing
     , personName = ""
     , personGender = Male
     , isPersonSelf = False

--- a/src/Updates.elm
+++ b/src/Updates.elm
@@ -11,6 +11,16 @@ update msg model =
         Save ->
             savePerson model
 
+        UpdatePerson person ->
+            ( { model
+                | personId = Just person.id
+                , personName = person.name
+                , personGender = person.gender
+                , isPersonSelf = person.isPersonSelf
+              }
+            , Cmd.none
+            )
+
         ChangePersonId personId ->
             ( { model | personId = personId }
             , Cmd.none
@@ -40,17 +50,34 @@ update msg model =
 
 savePerson : Model -> ( Model, Cmd Msg )
 savePerson model =
-    let
-        person =
-            newPerson model
+    case model.personId of
+        Just personId ->
+            let
+                updatePerson existingPerson =
+                    if personId == existingPerson.id then
+                        { existingPerson
+                            | name = model.personName
+                            , gender = model.personGender
+                            , isPersonSelf = model.isPersonSelf
+                        }
+                    else
+                        existingPerson
+            in
+                ( { model
+                    | people = List.map updatePerson model.people
+                    , personId = Nothing
+                    , personName = ""
+                    , isPersonSelf = False
+                  }
+                , Cmd.none
+                )
 
-        newPeople =
-            person :: model.people
-    in
-        ( { model
-            | people = newPeople
-            , personId = Nothing
-            , personName = ""
-          }
-        , Cmd.none
-        )
+        Nothing ->
+            ( { model
+                | people = newPerson model :: model.people
+                , personId = Nothing
+                , personName = ""
+                , isPersonSelf = False
+              }
+            , Cmd.none
+            )

--- a/src/Updates.elm
+++ b/src/Updates.elm
@@ -21,11 +21,6 @@ update msg model =
             , Cmd.none
             )
 
-        ChangePersonId personId ->
-            ( { model | personId = personId }
-            , Cmd.none
-            )
-
         ChangePersonName name ->
             ( { model | personName = name }
             , Cmd.none

--- a/src/Updates.elm
+++ b/src/Updates.elm
@@ -1,8 +1,9 @@
 module Updates exposing (update)
 
+import Material
 import Messages exposing (Msg(..))
 import Models exposing (Model, Person, newPerson)
-import Material
+
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
@@ -44,6 +45,6 @@ savePerson model =
         ( { model
             | people = newPeople
             , personName = ""
-        }
+          }
         , Cmd.none
         )

--- a/src/Updates.elm
+++ b/src/Updates.elm
@@ -21,8 +21,8 @@ update msg model =
             , Cmd.none
             )
 
-        ToggleIsYourself ->
-            ( { model | isYourself = not model.isYourself }
+        ToggleIsPersonSelf ->
+            ( { model | isPersonSelf = not model.isPersonSelf }
             , Cmd.none
             )
 

--- a/src/Updates.elm
+++ b/src/Updates.elm
@@ -2,7 +2,7 @@ module Updates exposing (update)
 
 import Material
 import Messages exposing (Msg(..))
-import Models exposing (Model, Person, newPerson)
+import Models exposing (Model, Person, newPerson, PersonId)
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -10,6 +10,11 @@ update msg model =
     case msg of
         Save ->
             savePerson model
+
+        ChangePersonId personId ->
+            ( { model | personId = personId }
+            , Cmd.none
+            )
 
         ChangePersonName name ->
             ( { model | personName = name }
@@ -44,6 +49,7 @@ savePerson model =
     in
         ( { model
             | people = newPeople
+            , personId = Nothing
             , personName = ""
           }
         , Cmd.none

--- a/src/Views.elm
+++ b/src/Views.elm
@@ -46,7 +46,7 @@ personForm model =
                     ]
                 ]
             , div []
-                [ checkbox ToggleIsYourself "Is this you?" ]
+                [ checkbox ToggleIsPersonSelf "Is this you?" ]
             , div []
                 [ button [] [ text "Save" ]
                 ]

--- a/src/Views.elm
+++ b/src/Views.elm
@@ -3,10 +3,9 @@ module Views exposing (..)
 import Html exposing (Html, div, text, label, input, span, button, h2, p)
 import Html.Attributes exposing (type_, name, placeholder, value, checked, style)
 import Html.Events exposing (onClick, onSubmit, onInput)
-import Material.Scheme
-import Material.Layout as Layout
 import Material.Grid exposing (grid, cell, size, Device(..))
-
+import Material.Layout as Layout
+import Material.Scheme
 import Messages exposing (Msg(..))
 import Models exposing (Model, Gender)
 
@@ -54,12 +53,13 @@ personForm model =
             ]
         ]
 
+
 checkbox : Msg -> String -> Html Msg
 checkbox msg name =
-  label []
-    [ input [ type_ "checkbox", onClick msg ] []
-    , text name
-    ]
+    label []
+        [ input [ type_ "checkbox", onClick msg ] []
+        , text name
+        ]
 
 
 radio : String -> Gender -> Gender -> Html Msg

--- a/src/Views.elm
+++ b/src/Views.elm
@@ -1,13 +1,13 @@
 module Views exposing (..)
 
-import Html exposing (Html, div, text, label, input, span, button, h2, p)
+import Html exposing (Html, div, text, label, input, span, button, h2, p, hr)
 import Html.Attributes exposing (type_, name, placeholder, value, checked, style)
 import Html.Events exposing (onClick, onSubmit, onInput)
 import Material.Grid exposing (grid, cell, size, Device(..))
 import Material.Layout as Layout
 import Material.Scheme
 import Messages exposing (Msg(..))
-import Models exposing (Model, Gender)
+import Models exposing (Model, Gender, Person)
 
 
 formView : Model -> Html Msg
@@ -19,6 +19,9 @@ formView model =
             , size Phone 2
             ]
             [ personForm model
+            , hr [] []
+            , peopleView model.people
+            , hr [] []
             , p [] [ text (toString model) ]
             ]
         ]
@@ -74,6 +77,19 @@ radio fieldLabel personGender gender =
             []
         , span [] [ text fieldLabel ]
         ]
+
+
+personView : Person -> Html Msg
+personView person =
+    div [ onClick (UpdatePerson person) ]
+        [ text (person.name ++ " (click to edit)")
+        ]
+
+
+peopleView : List Person -> Html Msg
+peopleView people =
+    div []
+        (List.map personView people)
 
 
 view : Model -> Html Msg


### PR DESCRIPTION
other updates
- add personId to model to denote which person we are editing in the form
- temporary person list
- code cleanup using elm-format
- reorder import alphabetically
- rename isYourself to isPersonSelf to remove ambiguity